### PR TITLE
EndPoint nuevo

### DIFF
--- a/src/com/strange/conversorDeMonedas/Principal/Principal.java
+++ b/src/com/strange/conversorDeMonedas/Principal/Principal.java
@@ -5,7 +5,7 @@ import com.strange.conversorDeMonedas.modules.Divisa;
 
 public class Principal {
     public static void main(String[] args) {
-        var conexionAPI = new ConexionAPI().conectarAPI("PEN");
+        var conexionAPI = new ConexionAPI().conectarAPI("USD","BRL");
         System.out.println(conexionAPI);
     }
 }

--- a/src/com/strange/conversorDeMonedas/modules/ConexionAPI.java
+++ b/src/com/strange/conversorDeMonedas/modules/ConexionAPI.java
@@ -9,25 +9,23 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
 public class ConexionAPI {
-    public JsonObject conectarAPI(String moneda){
-        var direcccion = URI.create("https://v6.exchangerate-api.com/v6/ea53538a7170746b7cf35a66/latest/"+moneda);
+    public Double conectarAPI(String monedaBase, String monedaDestino){
+        var direcccion = URI.create("https://v6.exchangerate-api.com/v6/ea53538a7170746b7cf35a66/pair/"+monedaBase+"/"+monedaDestino);
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(direcccion)
                 .build();
 
         try {
-            HttpResponse<String> response = client
-                    .send(request, HttpResponse.BodyHandlers.ofString());
-
-            //Parsear el JSON obtenido.
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            //Parsear el response.body(texto plano) obtenido y convertirlo a Json otra vez.
             JsonObject json = JsonParser.parseString(response.body()).getAsJsonObject();
-            //Obtener clave especifica (sub objeto Json) del JSON completo.
-            JsonObject divisas = json.getAsJsonObject("conversion_rates");
+            //Obtener clave especifica () del JSON completo.
+            Double tasaDeconversion = json.get("conversion_rate").getAsDouble();
             //retornamos la lista de conversiones como un JsonObject
-            return divisas;
+            return tasaDeconversion;
         } catch (Exception e) {
-            throw new RuntimeException("Error en la conexión con la API");
+            throw new RuntimeException("Error en la conexión con la API"+e.getMessage());
         }
     }
 }


### PR DESCRIPTION
### Cambio de EndPoint de estándar a Pair Conversion API
Se opto por un endpoint diferente a la estándar mostrado en la documentación de ExchangeRate-API.
Este endpoint por pares facilita la búsqueda de las divisas ingresando dos valores, la moneda base y la moneda de destino la cual se busca su equivalencia. Comparado con el endpoint anterior que devuelve todas las divisas registradas, este se adecua mas al requerimiento del proyecto.

### Enlace a Documentación con nueva dirección GET
https://www.exchangerate-api.com/docs/pair-conversion-requests

